### PR TITLE
FIX: fix clang-format and clang-tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   install_format_tidy:
     docker:
-      - image: ubuntu:latest
+      - image: ubuntu:22.04
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Run Clang-Tidy
           command: |
-            find . -iname "*.cpp" -o -iname "*.cc" -o -iname "*.h" | xargs clang-tidy -p .
+            find ./src -iname "*.cpp" -o -iname "*.cc" -o -iname "*.h" | xargs clang-tidy -p .
 
 
 workflows:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+Checks: '*, -llvm-header-guard, -google-runtime-references'
+CheckOptions:
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: '1'
+  - key: modernize-use-auto.MinTypeNameLength
+    value: '3'

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ cmake-build-debug-event-trace/
 *.app
 
 .vscode/
+.idea/

--- a/deps/depfile_parser.cc
+++ b/deps/depfile_parser.cc
@@ -113,7 +113,7 @@ bool DepfileParser::Parse(string* content, string* err) {
         { break; }
       yy4:
         ++in;
-      yy5: {
+      yy5 : {
         // For any other character (e.g. whitespace), swallow it here,
         // allowing the outer logic to loop around again.
         break;
@@ -135,7 +135,7 @@ bool DepfileParser::Parse(string* content, string* err) {
         if (yybm[0 + yych] & 128) {
           goto yy9;
         }
-      yy11: {
+      yy11 : {
         // Got a span of plain text.
         int len = (int)(in - start);
         // Need to shift it over if we're overwriting backslashes.
@@ -238,7 +238,7 @@ bool DepfileParser::Parse(string* content, string* err) {
           if (yych == ' ')
             goto yy28;
         }
-      yy26: {
+      yy26 : {
         // De-escape colon sign, but preserve other leading backslashes.
         // Regular expression uses lookahead to make sure that no whitespace
         // nor EOF follows. In that case it'd be the : at the end of a target

--- a/deps/eval_env.h
+++ b/deps/eval_env.h
@@ -54,7 +54,7 @@ struct EvalString {
  private:
   enum TokenType { RAW, SPECIAL };
 
-  typedef std::vector<std::pair<std::string, TokenType> > TokenList;
+  typedef std::vector<std::pair<std::string, TokenType>> TokenList;
   TokenList parsed_;
 };
 

--- a/deps/lexer.cc
+++ b/deps/lexer.cc
@@ -241,7 +241,7 @@ Lexer::Token Lexer::ReadToken() {
       }
     yy4:
       ++p;
-    yy5: {
+    yy5 : {
       token = ERROR;
       break;
     }
@@ -271,7 +271,7 @@ Lexer::Token Lexer::ReadToken() {
         if (yych == '#')
           goto yy32;
       }
-    yy11: {
+    yy11 : {
       token = INDENT;
       break;
     }
@@ -599,7 +599,7 @@ void Lexer::EatWhitespace() {
       { break; }
     yy79:
       ++p;
-    yy80: { break; }
+    yy80 : { break; }
     yy81:
       yych = *++p;
       if (yybm[0 + yych] & 128) {
@@ -794,7 +794,7 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
       }
     yy112:
       ++p;
-    yy113: {
+    yy113 : {
       last_token_ = start;
       return Error("bad $-escape (literal $ must be written as $$)", err);
     }

--- a/deps/subprocess.h
+++ b/deps/subprocess.h
@@ -101,7 +101,9 @@ struct SubprocessSet {
   /// 0 if not interruption.
   static int interrupted_;
 
-  static bool IsInterrupted() { return interrupted_ != 0; }
+  static bool IsInterrupted() {
+    return interrupted_ != 0;
+  }
 
   struct sigaction old_int_act_;
   struct sigaction old_term_act_;


### PR DESCRIPTION
1. previously, the clang-format problem is caused by the difference between clang-format on mac and clang-format on ubuntu:latest(also, now latest might be 24.04), so I change it to 22.04(in branch name it was mistaken for 20.04)
2. clang-tidy when including external library under /deps, literally generate millions of warnings and countless errors, we would not be able to fix that, tracking those files is meaningless. Also, exam all those file can reach the time limit for circleCI, we wont be able to fix that.